### PR TITLE
Fix fallback weather text position

### DIFF
--- a/weather_module.py
+++ b/weather_module.py
@@ -206,7 +206,9 @@ class WeatherModule:
                 error_text = "Weather data unavailable"
                 error_surface = self.font.render(error_text, True, COLOR_PASTEL_RED)
                 error_surface.set_alpha(TRANSPARENCY)
-                screen.blit(error_surface, position)
+                # Use extracted coordinates instead of the raw position
+                # tuple/dict so the fallback aligns with other elements
+                screen.blit(error_surface, (x, y))
         except Exception as e:
             logging.error(f"Error drawing weather module: {e}")
 


### PR DESCRIPTION
## Summary
- align fallback message using `x` and `y` coordinates in `weather_module.py`
- explain reason via inline comment

## Testing
- `python -m py_compile weather_module.py`


------
https://chatgpt.com/codex/tasks/task_e_684855362630832fa4da62a9b03e4d42